### PR TITLE
No activa display cuando el equipo esta bloqueado

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
     package="mode.retail.polaroid.mx.retailmode">
 
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
-    <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -41,6 +40,7 @@
             android:keepScreenOn="true"
             android:screenOrientation="portrait">
             <intent-filter>
+                <category android:name="android.intent.category.LAUNCHER" />
                 <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
                 <action android:name="android.app.action.DEVICE_ADMIN_DISABLED" />
             </intent-filter>
@@ -80,13 +80,28 @@
         <service
             android:name=".services.TimeService"
             android:enabled="true"
-            android:exported="true"
-            android:process=":externalprocess" />
+            android:exported="false"
+            android:stopWithTask="false"
+            android:process=":externalprocess"
+            android:permission="android.permission.BIND_JOB_SERVICE">
+
+            <intent-filter>
+                <action android:name="android.intent.action.START_SERVICE" />
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".services.CloseAppService"
+            android:stopWithTask="false" />
 
         <receiver
             android:name=".receiver.ScreenReceiver"
             android:enabled="true"
-            android:exported="true" />
+            android:exported="true">
+
+            <action android:name="android.intent.action.SCREEN_OFF" />
+            <action android:name="android.intent.action.SCREEN_ON" />
+        </receiver>
         <!--
  ATTENTION: This was auto-generated to add Google Play services to your project for
      App Indexing.  See https://g.co/AppIndexing/AndroidStudio for more information.

--- a/app/src/main/java/mode/retail/polaroid/mx/retailmode/receiver/ScreenReceiver.java
+++ b/app/src/main/java/mode/retail/polaroid/mx/retailmode/receiver/ScreenReceiver.java
@@ -4,10 +4,15 @@ import android.app.KeyguardManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.PowerManager;
+import android.view.Window;
+import android.view.WindowManager;
+import android.widget.Toast;
 
 import mode.retail.polaroid.mx.retailmode.MainActivity;
 import mode.retail.polaroid.mx.retailmode.RetailModeActivity;
+import mode.retail.polaroid.mx.retailmode.services.TimeService;
 
 public class ScreenReceiver extends BroadcastReceiver {
 
@@ -15,6 +20,32 @@ public class ScreenReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         //String action = intent.getAction();
 
-        RetailModeActivity.clearScreen();
+        //Toast.makeText(context, "Receiver display", Toast.LENGTH_LONG).show();
+
+        if (intent.getAction().equals(Intent.ACTION_SCREEN_OFF)) {
+            RetailModeActivity.unlockScreen();
+
+            // Unlock the screen
+            PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+            PowerManager.WakeLock wl = pm.newWakeLock(
+                    PowerManager.FULL_WAKE_LOCK
+                            | PowerManager.ACQUIRE_CAUSES_WAKEUP
+                            | PowerManager.ON_AFTER_RELEASE,
+                    "RetailMode");
+            wl.acquire();
+
+            KeyguardManager km = (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
+            KeyguardManager.KeyguardLock kl = km.newKeyguardLock("RetailMode");
+            kl.disableKeyguard();
+
+            Intent i = new Intent(context, RetailModeActivity.class);
+            i.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+            context.startActivity(i);
+            wl.release();
+        } else if (intent.getAction().equals(Intent.ACTION_SCREEN_ON)) {
+            Intent i = new Intent(context, RetailModeActivity.class);
+            i.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+            context.startActivity(i);
+        }
     }
 }

--- a/app/src/main/res/layout/activity_retail_mode.xml
+++ b/app/src/main/res/layout/activity_retail_mode.xml
@@ -8,6 +8,7 @@
     tools:context="mode.retail.polaroid.mx.retailmode.RetailModeActivity">
 
     <VideoView android:id="@+id/retailModeView"
+        android:keepScreenOn="true"
         android:layout_width="fill_parent"
         android:layout_alignParentRight="true"
         android:layout_alignParentLeft="true"


### PR DESCRIPTION
Al cerrar la app, ya no se re-activa por sí sola.

Se creo un servicio que detecta el cierre de la app, y este será el encargado de revivir la aplicación generando nuevos procesos.

Se habilito el display cuando el equipo se encuentra bloqueado.

#12 